### PR TITLE
fix: update navigation path to boards

### DIFF
--- a/src/common/components/panels/database/GamesTable.tsx
+++ b/src/common/components/panels/database/GamesTable.tsx
@@ -39,7 +39,7 @@ function GamesTable({ games, loading }: { games: NormalizedGame[]; loading: bool
                   pgn: game.moves,
                   headers: game,
                 });
-                navigate({ to: "/" });
+                navigate({ to: "/boards" });
               }}
             >
               <IconEye size="1rem" stroke={1.5} />

--- a/src/features/accounts/components/PersonalCardPanels/OpeningsPanel.tsx
+++ b/src/features/accounts/components/PersonalCardPanels/OpeningsPanel.tsx
@@ -168,7 +168,7 @@ function OpeningDetail({ opening, totalGames, color }: { opening: OpeningStats; 
               setActiveTab,
               position: Array(countMainPly(tree.root)).fill(0),
             });
-            navigate({ to: "/" });
+            navigate({ to: "/boards" });
           }}
         >
           {opening.name}

--- a/src/features/databases/components/GameTable.tsx
+++ b/src/features/databases/components/GameTable.tsx
@@ -224,7 +224,7 @@ function GameTable() {
                 id: record.id,
               },
             });
-            navigate({ to: "/" });
+            navigate({ to: "/boards" });
           }}
           columns={[
             {

--- a/src/features/databases/components/TournamentCard.tsx
+++ b/src/features/databases/components/TournamentCard.tsx
@@ -152,7 +152,7 @@ function TournamentCard({ tournament, file }: { tournament: Event; file: string 
                             id: game.id,
                           },
                         });
-                        navigate({ to: "/" });
+                        navigate({ to: "/boards" });
                       }}
                     >
                       <IconEye size="1rem" stroke={1.5} />

--- a/src/features/files/components/DirectoryTable.tsx
+++ b/src/features/files/components/DirectoryTable.tsx
@@ -198,7 +198,7 @@ function Table({
         srcInfo: record,
         gameNumber: 0,
       });
-      navigate({ to: "/" });
+      navigate({ to: "/boards" });
     },
     [selected, setActiveTab, setTabs, navigate],
   );


### PR DESCRIPTION
## Description

This change ensures that a double-click on a game file navigates users to the board view instead of the home view

## Type of change
- [x] Bug fix
