### PR TITLE
fix: Add Puzzle modal size and puzzle count

### DIFF
--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -53,8 +53,8 @@ const PUZZLE_DATABASES: any[] = [
   {
     title: "Lichess Puzzles",
     description: "A collection of all puzzles from Lichess.org",
-    puzzle_count: 3080529,
-    storage_size: 339046400,
+    puzzleCount: 3080529,
+    storageSize: 339046400,
     downloadLink: "https://pub-561e4f3376ea4e4eb2ffd01a876ba46e.r2.dev/puzzles.db3",
   },
 ];


### PR DESCRIPTION
## Description

Ensures SIZE and PUZZLES render correctly in AddPuzzle modal by updating PUZZLE_DATABASES to match PuzzleDatabaseInfo


## Steps to Reproduce

- Open the “Add Database” modal from the Puzzles section.
- “SIZE” shows NaN undefined and “PUZZLES” shows 0.


## Type of change
- [x] Bug fix
