### PR TITLE
feat: Add recent online games from Chess.com and Lichess.org

### DIFF
--- a/src/features/dashboard/components/RecentOnlineGames.tsx
+++ b/src/features/dashboard/components/RecentOnlineGames.tsx
@@ -1,0 +1,131 @@
+import { ActionIcon, Button, Card, Group, Loader, ScrollArea, Stack, Table, Text, Tooltip } from "@mantine/core";
+import { IconRefresh } from "@tabler/icons-react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useState, useCallback } from "react";
+import { sessionsAtom, tabsAtom, activeTabAtom } from "@/state/atoms";
+import { useNavigate } from "@tanstack/react-router";
+import { createTab } from "@/utils/tabs";
+
+type GenericGame = {
+  id: string;
+  opponent: string;
+  opponentRating?: number;
+  result: 'Won' | 'Lost' | 'Draw';
+  movesCount?: number;
+  date: string;
+  pgn: string;
+  userColor: 'white' | 'black';
+};
+
+type RecentOnlineGamesProps = {
+    platform: 'lichess' | 'chess.com';
+    title: string;
+    fetchGamesFn: (username: string) => Promise<any[]>;
+    gameAdapter: (game: any, username: string) => GenericGame;
+};
+
+export default function RecentOnlineGames({ platform, title, fetchGamesFn, gameAdapter }: RecentOnlineGamesProps) {
+    const [games, setGames] = useState<GenericGame[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [fetchAttempted, setFetchAttempted] = useState(false);
+    const sessions = useAtomValue(sessionsAtom);
+    const session = sessions.find(s => (s.lichess && platform === 'lichess') || (s.chessCom && platform === 'chess.com'));
+    const navigate = useNavigate();
+    const setTabs = useSetAtom(tabsAtom);
+    const setActiveTab = useSetAtom(activeTabAtom);
+
+    const username = platform === 'lichess' ? session?.lichess?.username : session?.chessCom?.username;
+
+    const fetchGames = useCallback(async () => {
+        if (username) {
+            setLoading(true);
+            setError(null);
+            setFetchAttempted(true);
+            try {
+                const fetchedGames = await fetchGamesFn(username);
+                const adaptedGames = fetchedGames
+                    .slice(0, 5)
+                    .map(game => gameAdapter(game, username));
+                setGames(adaptedGames);
+            } catch (err) {
+                console.error("Failed to fetch recent games:", err);
+                setError("Could not load recent games.");
+            } finally {
+                setLoading(false);
+            }
+        }
+    }, [username, fetchGamesFn, gameAdapter]);
+
+    const handleAnalyse = (game: GenericGame) => {
+        if (!game.pgn) return;
+        const whiteUsername = game.userColor === 'white' ? username : game.opponent;
+        const blackUsername = game.userColor === 'black' ? username : game.opponent;
+        createTab({
+            tab: {
+                name: `${whiteUsername} vs ${blackUsername}`,
+                type: "analysis",
+            },
+            setTabs,
+            setActiveTab,
+            pgn: game.pgn,
+        });
+        navigate({ to: "/boards" });
+    };
+
+    if (!session) {
+        return null;
+    }
+
+    return (
+        <Card withBorder p="lg" radius="md" h="100%">
+            <Stack h="100%">
+                <Group justify="space-between">
+                    <Text fw={700}>{title}</Text>
+                    <Tooltip label="Refresh">
+                        <ActionIcon variant="default" size="sm" onClick={fetchGames} disabled={loading}>
+                           {loading ? <Loader size="xs" /> : <IconRefresh size="0.8rem" />}
+                        </ActionIcon>
+                    </Tooltip>
+                </Group>
+                <ScrollArea h="100%" type="auto">
+                    <Table striped highlightOnHover>
+                        <Table.Thead>
+                            <Table.Tr>
+                                <Table.Th>Opponent</Table.Th>
+                                <Table.Th>Result</Table.Th>
+                                <Table.Th>Moves</Table.Th>
+                                <Table.Th>Date</Table.Th>
+                                <Table.Th></Table.Th>
+                            </Table.Tr>
+                        </Table.Thead>
+                        <Table.Tbody>
+                            {games.map(g => (
+                                <Table.Tr key={g.id}>
+                                    <Table.Td>{g.opponent} {g.opponentRating && `(${g.opponentRating})`}</Table.Td>
+                                    <Table.Td>{g.result}</Table.Td>
+                                    <Table.Td>{g.movesCount ?? '-'}</Table.Td>
+                                    <Table.Td>{g.date}</Table.Td>
+                                    <Table.Td>
+                                        <Button size="xs" variant="light" onClick={() => handleAnalyse(g)}>Analyse</Button>
+                                    </Table.Td>
+                                </Table.Tr>
+                            ))}
+                        </Table.Tbody>
+                    </Table>
+                    {loading && (
+                        <Group justify="center" mt="md">
+                            <Loader size="sm" />
+                        </Group>
+                    )}
+                    {error && <Text c="red" size="sm" ta="center" mt="md">{error}</Text>}
+                    {fetchAttempted && !loading && !error && games.length === 0 && (
+                        <Text c="dimmed" size="sm" ta="center" mt="md">
+                            No recent games found.
+                        </Text>
+                    )}
+                </ScrollArea>
+            </Stack>
+        </Card>
+    );
+}

--- a/src/utils/lichess/api.tsx
+++ b/src/utils/lichess/api.tsx
@@ -227,6 +227,36 @@ export async function getLichessAccount({
   return response.json();
 }
 
+export async function fetchLastLichessGames(username: string, count: number = 5) {
+  const url = `${baseURL}/games/user/${username}?max=${count}&pgnInJson=true&opening=true`;
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/x-ndjson" },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch games: ${response.statusText}`);
+    }
+
+    const text = await response.text();
+    const games = text
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    return games;
+  } catch (e) {
+    error(`Error fetching last Lichess games for ${username}: ${e}`);
+    notifications.show({
+      title: "Fetch Error",
+      message: `Could not fetch recent games for ${username} from Lichess.`,
+      color: "red",
+      icon: <IconX />,
+    });
+    return [];
+  }
+}
+
 export async function getBestMoves(
   _tab: string,
   _goMode: GoMode,


### PR DESCRIPTION
<!-- Pull Request Template -->
Description
This pull request introduces a Proof of Concept enhancement to the user dashboard by adding recent online games from both Lichess.org and Chess.com. Previously, the dashboard only displayed recent local games. This change provides users with a more seamless experience, allowing them to quickly view and launch an analysis of their latest online matches directly from the main screen.

The implementation includes:
A new, reusable React component, RecentOnlineGames.tsx, to display game lists from different platforms. This can further be simplified into a RecentGames component or simialr but I seprated it to more easily distinguish between existing and new functionality
API utility functions in lichess/api.tsx and chess.com/api.tsx to fetch the latest games for a user.
Conditional rendering on the main DashboardPage.tsx to only show the recent games components if the user has linked the corresponding online accounts.
A manual refresh button on each component to fetch the latest games on demand, avoiding API rate-limiting issues on startup.

Fixes # (issue)

Type of change
[ ] Bug fix
[x] New feature
[ ] Breaking change
[ ] Documentation update

Checklist
[x] My code follows the style guidelines of this project
[x] I have performed a self-review of my own code
[x] I have commented my code, particularly in hard-to-understand areas
[ ] I have made corresponding changes to the documentation
[x] My changes generate no new warnings
[ ] I have added tests that prove my fix is effective or that my feature works
[ ] New and existing unit tests pass locally with my changes

Additional context
New Dashboard View:
<img width="2526" height="1380" alt="image" src="https://github.com/user-attachments/assets/0f10bdf4-737a-4f39-a52a-cabe3a91e3d4" />

