### PR TITLE
feat: local puzzle database

### DIFF
--- a/src/common/components/puzzles/AddPuzzle.tsx
+++ b/src/common/components/puzzles/AddPuzzle.tsx
@@ -6,6 +6,7 @@ import useSWRImmutable from "swr/immutable";
 import { commands, events, type PuzzleDatabaseInfo } from "@/bindings";
 import ProgressButton from "@/common/components/ProgressButton";
 import { getDefaultPuzzleDatabases } from "@/utils/db";
+import { type FileMetadata, type Directory } from "@/features/files/components/file";
 import { formatBytes, formatNumber } from "@/utils/format";
 import { getPuzzleDatabases } from "@/utils/puzzles";
 
@@ -14,11 +15,13 @@ function AddPuzzle({
   opened,
   setOpened,
   setPuzzleDbs,
+  files,
 }: {
   puzzleDbs: PuzzleDatabaseInfo[];
   opened: boolean;
   setOpened: (opened: boolean) => void;
   setPuzzleDbs: Dispatch<SetStateAction<PuzzleDatabaseInfo[]>>;
+  files: (FileMetadata | Directory)[] | undefined;
 }) {
   const { data: dbs, error } = useSWRImmutable("default_puzzle_databases", getDefaultPuzzleDatabases);
 
@@ -33,6 +36,7 @@ function AddPuzzle({
               key={i}
               setPuzzleDbs={setPuzzleDbs}
               initInstalled={puzzleDbs.some((e) => e.title === db.title)}
+              files={files}
             />
           ))}
           {error && (
@@ -51,11 +55,13 @@ function PuzzleDbCard({
   puzzleDb,
   databaseId,
   initInstalled,
+  files,
 }: {
   setPuzzleDbs: Dispatch<SetStateAction<PuzzleDatabaseInfo[]>>;
   puzzleDb: PuzzleDatabaseInfo & { downloadLink: string };
   databaseId: number;
   initInstalled: boolean;
+  files: (FileMetadata | Directory)[] | undefined;
 }) {
   const [inProgress, setInProgress] = useState<boolean>(false);
 
@@ -63,7 +69,7 @@ function PuzzleDbCard({
     setInProgress(true);
     const path = await resolve(await appDataDir(), "puzzles", `${name}.db3`);
     await commands.downloadFile(`puzzle_db_${id}`, url, path, null, null, null);
-    setPuzzleDbs(await getPuzzleDatabases());
+    setPuzzleDbs(await getPuzzleDatabases(files || []));
   }
 
   return (

--- a/src/common/components/puzzles/PuzzleBoard.tsx
+++ b/src/common/components/puzzles/PuzzleBoard.tsx
@@ -63,15 +63,12 @@ function PuzzleBoard({
       }
     }
   }
-  const orientation = puzzle?.fen
-    ? Chess.fromSetup(parseFen(puzzle.fen).unwrap()).unwrap().turn === "white"
-      ? "black"
-      : "white"
-    : "white";
+  const turn = pos?.turn || "white";
+  let orientation = turn;
+  
   const [pendingMove, setPendingMove] = useState<NormalMove | null>(null);
 
   const dests = pos ? chessgroundDests(pos) : new Map();
-  const turn = pos?.turn || "white";
   const showCoordinates = useAtomValue(showCoordinatesAtom);
 
   function checkMove(move: Move) {

--- a/src/common/components/puzzles/Puzzles.tsx
+++ b/src/common/components/puzzles/Puzzles.tsx
@@ -18,9 +18,12 @@ import {
 } from "@mantine/core";
 import { useSessionStorage } from "@mantine/hooks";
 import { IconPlus, IconX, IconZoomCheck } from "@tabler/icons-react";
-import { Chess, parseUci } from "chessops";
-import { parseFen } from "chessops/fen";
+
+import { Chess, makeUci, parseUci } from "chessops";
+import { INITIAL_BOARD_FEN, parseFen } from "chessops/fen";
 import { useAtom, useSetAtom } from "jotai";
+import { useLoaderData } from "@tanstack/react-router";
+import useSWR from "swr";
 import { useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
@@ -36,6 +39,7 @@ import {
   jumpToNextPuzzleAtom,
   progressivePuzzlesAtom,
   puzzleRatingRangeAtom,
+
   selectedPuzzleDbAtom,
   tabsAtom,
 } from "@/state/atoms";
@@ -46,6 +50,24 @@ import { defaultTree } from "@/utils/treeReducer";
 import { unwrap } from "@/utils/unwrap";
 import AddPuzzle from "./AddPuzzle";
 import PuzzleBoard from "./PuzzleBoard";
+import { readDir, remove } from "@tauri-apps/plugin-fs";
+import { type Directory, type FileMetadata, type FileType, processEntriesRecursively } from "@/features/files/components/file";
+import { parseSan } from "chessops/san";
+
+const useFileDirectory = (dir: string) => {
+  const { data, error, isLoading, mutate } = useSWR("file-directory", async () => {
+    const entries = await readDir(dir);
+    const allEntries = processEntriesRecursively(dir, entries);
+
+    return allEntries;
+  });
+  return {
+    files: data,
+    isLoading,
+    error,
+    mutate,
+  };
+};
 
 function Puzzles({ id }: { id: string }) {
   const { t } = useTranslation();
@@ -63,13 +85,16 @@ function Puzzles({ id }: { id: string }) {
   const [puzzleDbs, setPuzzleDbs] = useState<PuzzleDatabaseInfo[]>([]);
   const [selectedDb, setSelectedDb] = useAtom(selectedPuzzleDbAtom);
 
-  useEffect(() => {
-    getPuzzleDatabases().then((databases) => {
-      setPuzzleDbs(databases);
-    });
-  }, []);
+  const { documentDir } = useLoaderData({ from: "/boards" });
+    const { files, isLoading } = useFileDirectory(documentDir);
 
-  const [ratingRange, setRatingRange] = useAtom(puzzleRatingRangeAtom);
+  useEffect(() => {
+    if (files) {
+      getPuzzleDatabases(files as (FileMetadata | Directory)[]).then((databases) => {
+        setPuzzleDbs(databases);
+      });
+    }
+  }, [files]);  const [ratingRange, setRatingRange] = useAtom(puzzleRatingRangeAtom);
 
   const [jumpToNextPuzzleImmediately, setJumpToNextPuzzleImmediately] = useAtom(jumpToNextPuzzleAtom);
 
@@ -80,10 +105,13 @@ function Puzzles({ id }: { id: string }) {
 
   function setPuzzle(puzzle: { fen: string; moves: string[] }) {
     setFen(puzzle.fen);
-    makeMove({ payload: parseUci(puzzle.moves[0])! });
+    if (puzzle.moves.length % 2 === 0) {
+      console.log("Setting puzzle. Puzzle has even moves. Player must play second");
+      makeMove({ payload: parseUci(puzzle.moves[0])! });
+    }
   }
 
-  function generatePuzzle(db: string) {
+  async function generatePuzzle(db: string) {
     let range = ratingRange;
     if (progressive) {
       const rating = puzzles?.[currentPuzzle]?.rating;
@@ -92,19 +120,72 @@ function Puzzles({ id }: { id: string }) {
         setRatingRange([rating + 50, rating + 100]);
       }
     }
-    commands.getPuzzle(db, range[0], range[1]).then((res) => {
-      const puzzle = unwrap(res);
-      const newPuzzle: Puzzle = {
-        ...puzzle,
-        moves: puzzle.moves.split(" "),
+
+    // Find the database info to check its type
+    const dbInfo = puzzleDbs.find(p => p.path === db);
+    if (!dbInfo) return;
+
+    let puzzle: Puzzle;
+    if (dbInfo.path.endsWith('.db3')) {
+      // Handle .db3 database puzzles
+      const res = await commands.getPuzzle(db, range[0], range[1]);
+      const dbPuzzle = unwrap(res);
+      puzzle = {
+        ...dbPuzzle,
+        moves: dbPuzzle.moves.split(" "),
         completion: "incomplete",
       };
-      setPuzzles((puzzles) => {
-        return [...puzzles, newPuzzle];
-      });
-      setCurrentPuzzle(puzzles.length);
-      setPuzzle(newPuzzle);
+    } else {
+      // Handle .pgn puzzle files
+      const count = unwrap(await commands.countPgnGames(db));
+      const games = unwrap(await commands.readGames(db, 0, count-1)); // Read all games
+      if (games.length === 0) return;
+      
+      // Select a random game from the file
+      const game = games[Math.floor(Math.random() * games.length)];
+      const tokens = unwrap(await commands.lexPgn(game));
+      
+      // Extract FEN and moves from PGN
+      const headers = tokens.filter(t => t.type === "Header")
+        .reduce((acc, t) => ({ ...acc, [t.value.tag]: t.value.value }), {} as Record<string, string>);
+
+      const puzzleFen = headers.FEN || INITIAL_BOARD_FEN;
+      
+      const [pos, error] = positionFromFen(puzzleFen);
+          
+      const parsedMoves = tokens.filter(t => t.type === "San")
+        .map(t => t.value)
+        .map(san => {
+          if (pos) {
+            const move = parseSan(pos, san);          
+            const uciMove = move ? makeUci(move) : null;
+            if (move) {
+              pos.play(move);
+            }
+            return uciMove;            
+          }
+          return null;
+        });
+
+      parsedMoves.some((move) => move === null) && console.warn("Some moves could not be parsed from SAN to UCI. This needs to be fixed.");
+      const moves = parsedMoves.filter((move) => move !== null); // Filter out any null moves
+
+      puzzle = {
+        fen: puzzleFen,
+        moves,
+        rating: 1500, // Default rating for PGN puzzles
+        rating_deviation: 0,
+        popularity: 0,
+        nb_plays: 0,
+        completion: "incomplete"
+      };
+    }
+
+    setPuzzles((puzzles) => {
+      return [...puzzles, puzzle];
     });
+    setCurrentPuzzle(puzzles.length);
+    setPuzzle(puzzle);
   }
 
   function changeCompletion(completion: Completion) {
@@ -140,7 +221,7 @@ function Puzzles({ id }: { id: string }) {
       </Portal>
       <Portal target="#topRight" style={{ height: "100%" }}>
         <Paper h="100%" withBorder p="md">
-          <AddPuzzle puzzleDbs={puzzleDbs} opened={addOpened} setOpened={setAddOpened} setPuzzleDbs={setPuzzleDbs} />
+          <AddPuzzle puzzleDbs={puzzleDbs} opened={addOpened} setOpened={setAddOpened} setPuzzleDbs={setPuzzleDbs} files={files} />
           <Group grow>
             <div>
               <Text size="sm" c="dimmed">


### PR DESCRIPTION
<!-- Pull Request Template -->

## Description

Chessifier/En Croissant allows the user to create a pgn file with the type "Puzzle" but it does nothing. This PR make these file selectable as a local puzzle database in the PuzzleBoard instead of the downloadable lichess puzzle database.

## Type of change
- [x] New feature

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Draft PR TODO:

- [ ] Adapt file edition layout when editing a puzzle database, to provide a way to set a rating. To better integrate with the current puzzle board puzzle selection
- [ ] More tests with different puzzle setups. Current detection of who's turn is first is grafted onto the old system that assumed format in the db.
- [ ] Figure out the blinking when completing a puzzle. Seems to be related to the orientation changes

